### PR TITLE
Ensure all relevant tokens are added to the parameter object

### DIFF
--- a/lib/model/class_parameter_list.rb
+++ b/lib/model/class_parameter_list.rb
@@ -55,6 +55,10 @@ class ClassParameterList
       end
 
       if (token.type == :COMMA || token == @tokens.last) && stack.empty? && parameter.tokens.any?
+        unless [:COMMA, :NEWLINE, :WHITESPACE, :INDENT].include?(token.type)
+          parameter.add(token)
+        end
+
         # always add a comma and a newline token at the end of each parameter
         parameter.add(PuppetLint::Lexer::Token.new(:COMMA, ",", 0,0))
         parameter.add(PuppetLint::Lexer::Token.new(:NEWLINE, "\n", 0,0))

--- a/puppet-lint-class_parameter-check.gemspec
+++ b/puppet-lint-class_parameter-check.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'puppet-lint-class_parameter-check'
-  spec.version     = '0.1.2'
+  spec.version     = '0.1.3'
   spec.licenses    = ['MIT']
   spec.summary     = "Puppet lint check for class parameters"
   spec.description = <<-EOF

--- a/spec/puppet-lint/plugins/check_class_parameter_spec.rb
+++ b/spec/puppet-lint/plugins/check_class_parameter_spec.rb
@@ -27,6 +27,14 @@ describe 'class_parameter' do
           expect(problems).to have(0).problems
         end
 
+        context 'in one line' do
+          let(:code) { "class puppet_module(String $alphabetical, String $non_alphabetical){ }" }
+
+          it 'has no problems' do
+            expect(problems).to have(0).problems
+          end
+        end
+
         context 'with hash parameters' do
           let(:code) { <<-EOF
             class puppet_module(


### PR DESCRIPTION
Fixes bug where a relatively common class definition would crash the puppet lint check.
