### PR TITLE
Fix plugin crashing when a syntax error occurs

### DIFF
--- a/lib/model/parameter.rb
+++ b/lib/model/parameter.rb
@@ -1,4 +1,5 @@
 class Parameter
+  class SyntaxError < StandardError; end
   attr_accessor :documentation
 
   def initialize
@@ -20,10 +21,12 @@ class Parameter
   end
 
   def add(token)
-    # A parameter never starts with a newline token
-    unless @tokens.empty? && token.type == :NEWLINE
-      @tokens << token
-    end
+    # A parameter never starts with a newline token, so skip that one
+    return if @tokens.empty? && token.type == :NEWLINE
+    # Raise a syntax error if the parameter starts with a comma.
+    raise SyntaxError, "Syntax error: Expected a parameter definition, found comma on line #{token.line}, column #{token.column}" if @tokens.empty? && token.type == :COMMA
+
+    @tokens << token
   end
 
   def tokens

--- a/lib/model/parameter.rb
+++ b/lib/model/parameter.rb
@@ -27,8 +27,7 @@ class Parameter
   end
 
   def tokens
-    sanitized_tokens = strip_starting_newlines(@tokens)
-    return strip_ending_newlines(sanitized_tokens)
+    strip_newlines(@tokens)
   end
 
   def line
@@ -50,6 +49,11 @@ class Parameter
   end
 
   private
+  def strip_newlines(tokens)
+    stripped_tokens = strip_starting_newlines(tokens)
+    strip_ending_newlines(stripped_tokens)
+  end
+
   def strip_starting_newlines(tokens)
     tokens.inject([]) do |memo, token|
       unless memo.empty? && token.type == :NEWLINE

--- a/lib/puppet-lint/plugins/check_class_parameter.rb
+++ b/lib/puppet-lint/plugins/check_class_parameter.rb
@@ -13,9 +13,13 @@ PuppetLint.new_check(:class_parameter) do
         puppet_class.parameter_list.errors.each { |error| notify :error, error }
       end
     end
+  rescue Parameter::SyntaxError => error
+    notify :error, { message: error, line: nil, column: nil }
   end
 
   def fix(problem)
+    # Puppet linter wants to fix each problem. This method fixes all problems
+    # at once. Checking the @fixed makes sure code is executed only once.
     return if @fixed
 
     resorted_tokens = []

--- a/puppet-lint-class_parameter-check.gemspec
+++ b/puppet-lint-class_parameter-check.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'puppet-lint-class_parameter-check'
-  spec.version     = '0.2.0'
+  spec.version     = '0.2.1'
   spec.licenses    = ['MIT']
   spec.summary     = "Puppet lint check for class parameters"
   spec.description = <<-EOF

--- a/spec/puppet-lint/plugins/check_class_parameter_spec.rb
+++ b/spec/puppet-lint/plugins/check_class_parameter_spec.rb
@@ -167,6 +167,20 @@ describe 'class_parameter' do
           expect(problems).to have(3).problems
         end
       end
+
+      context 'with a double comma syntax error' do
+        let(:code) { <<-EOF
+          class puppet_module(
+            String $alphabetical,
+            String $alphabetical_optional = "default",,
+          ) { }
+          EOF
+        }
+
+        it 'has a problem' do
+          expect(problems).to have(1).problems
+        end
+      end
     end
   end
 


### PR DESCRIPTION
It would crash if you use a double comma
