### PR TITLE
Fix #24; Allow Hash as parameter value

### DIFF
--- a/lib/model/parameter_list.rb
+++ b/lib/model/parameter_list.rb
@@ -54,9 +54,9 @@ class ParameterList
     stack = []
 
     @tokens.inject([]) do |memo, token|
-      if [:LBRACK, :LPAREN].include?(token.type)
+      if [:LBRACK, :LPAREN, :LBRACE].include?(token.type)
         stack.push(true)
-      elsif [:RBRACK, :RPAREN].include?(token.type)
+      elsif [:RBRACK, :RPAREN, :RBRACE].include?(token.type)
         stack.pop
       end
 


### PR DESCRIPTION
This fix was developed by @usev6 in https://github.com/rodjek/puppet-lint/issues/926. I tested it on the puppet-collectd module and can verify that it fixes https://github.com/ryreitsma/puppet-lint-class_parameter-check/issues/24.